### PR TITLE
Add Meilisearch and Typesense to Search engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The following columnar databases use a [shared-nothing architecture](https://en.
 - [Elasticsearch](https://www.elastic.co/) - Search and analytics engine based on Apache Lucene.
 - [OpenSearch](https://opensearch.org/) - Apache 2.0 fork of Elasticsearch.
 - [Quickwit](https://quickwit.io/) - Search engine on top of object storage, using shared-everything architecture.
+- [Meilisearch](https://www.meilisearch.com/) - Open source search engine, aims to be a ready-to-go solution.
 
 ### NewSQL
  

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The following columnar databases use a [shared-nothing architecture](https://en.
 - [OpenSearch](https://opensearch.org/) - Apache 2.0 fork of Elasticsearch.
 - [Quickwit](https://quickwit.io/) - Search engine on top of object storage, using shared-everything architecture.
 - [Meilisearch](https://www.meilisearch.com/) - Open source search engine, aims to be a ready-to-go solution.
+- [Typesense](https://typesense.org/) - Оpen-source, typo-tolerant search engine optimized for instant search-as-you-type experiences and developer productivity.
 
 ### NewSQL
  


### PR DESCRIPTION
Recently I found two search engines: Meilisearch and Typesense. Both is opensource solutions, built from ground and used in production. I think they should be on this list.