### PR TITLE
Add h5i-db to OLAP Databases > Timeseries

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ HTAP (Hybrid Transactional-Analytical Processing) databases handle both transact
 Time-series databases are optimized for append-heavy workloads where data is tagged, timestamped, and queried by time range — distinct from general OLAP because they prioritize ingestion throughput, automatic retention, and time-aligned aggregations.
 
 - [Grafana Mimir](https://grafana.com/oss/mimir/) - Prometheus-compatible TSDB on top of object storage, horizontally scalable.
+- [h5i-db](https://db.h5i.dev) - Embedded time series database in Rust that queries Parquet through DataFusion SQL with ASOF joins and time bucketing, and versions every write so any past state reads in constant time; use it for local analytical and quant research workloads where a server TSDB is too much operational weight.
 - [InfluxDB](https://www.influxdata.com/) - Purpose-built time series database optimized for high-write-throughput metrics, events, and IoT data with a SQL-like query language.
 - [Prometheus](https://prometheus.io/) - Pull-based metrics collection and time series database, de facto standard for cloud-native monitoring.
 - [QuestDB](https://questdb.io/) - High-performance time series database written in Java and C++, with SQL support and ingestion rates exceeding millions of rows per second.


### PR DESCRIPTION
Adds **h5i-db** to OLAP Databases > Timeseries, in alphabetical position after Grafana Mimir.

| Field | Value |
|---|---|
| **Tool name** | h5i-db |
| **URL** | https://db.h5i.dev |
| **One-line description** | Embedded time series database in Rust that queries Parquet through DataFusion SQL with ASOF joins and time bucketing, and versions every write so any past state reads in constant time; use it for local analytical and quant research workloads where a server TSDB is too much operational weight. |
| **Target section** | Timeseries |
| **Why it belongs here** | Every current entry in that section is a server or cluster deployment. h5i-db covers the in-process end of the same workload shape, and adds versioning and point-in-time reads that none of the existing entries provide. |

**Details:** columnar storage on Parquet, DataFusion for SQL, plus time series operators (ASOF join, timezone aware `time_bucket`, gapfill/resample, rolling windows, `vwap`, `ewma`). Storage is immutable: each write is an atomic commit, so you can read any past version in O(1) or pin a read to a decision time and get only the data that had arrived by then. One directory on disk, no server, no daemon.

**Checks:**
- Actively maintained: v0.1.0 released this week, commits ongoing. Apache-2.0, open source, free to evaluate.
- Description says what it does and when you would use it, capitalized, ends in a period.
- Alphabetical order within the section, no duplicate entry.
- Changes are in `README.md` only, on a dedicated branch.
- `npx awesome-lint README.md` reports no errors attributable to this change (the two it does report, `awesome-github` on a shallow fork clone and a pre-existing missing ToC entry for "📝 License", are both present before my edit).

**Disclosure:** I am the author of h5i-db. It is early (v0.1.0), so no hard feelings if you would rather wait for more adoption.
