### PR TITLE
Add KoldStore to Storage engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Fully managed cloud data warehouses trade self-hosted operational overhead for e
 Storage engines are the foundational frameworks on top of which higher-level databases and data systems are built. They handle durability, transactions, and low-level data organization.
 
 - [FoundationDB](https://www.foundationdb.org/) - Distributed ordered key-value store with full ACID transactions, designed as a reliable foundation layer for building higher-level databases and services.
+- [KoldStore](https://github.com/kalamdb/koldstore) - PostgreSQL tiered-storage that moves historical rows to Parquet while keeping the original table fully queryable and supporting updates and deletes.
 - [LevelDB](https://github.com/google/leveldb) - Google's embeddable key-value store using a log-structured merge-tree (LSM-tree); the inspiration for RocksDB and widely used in Blockchain and embedded systems.
 - [RocksDB](https://rocksdb.org/) - Embeddable persistent key-value store by Meta, optimized for fast storage and used as the storage engine inside many distributed databases (TiKV, CockroachDB, Kafka).
 


### PR DESCRIPTION
| Field | Value |
|---|---|
| **Tool name** | KoldStore |
| **URL** | https://github.com/kalamdb/koldstore |
| **One-line description** | PostgreSQL tiered-storage that moves historical rows to Parquet while keeping the original table fully queryable and supporting updates and deletes. |
| **Target section** | Storage engines |
| **Why it belongs here** | PostgreSQL tiered-storage extension that moves historical data to Parquet while keeping the original table queryable, bridging transactional hot storage and analytical/cold storage. |

## Validation

- README diff passes `git diff --check`.
- The repository `lint` workflow is awaiting maintainer approval for this fork PR.