### PR TITLE
fix: add missing license entry to table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ A curated list of **OLAP databases**, **data engineering** tools, **columnar dat
 - [🤝 Contributing](#-contributing)
 - [👤 Contributors](#-contributors)
 - [💫 Show your support](#-show-your-support)
+- [📝 License](#-license)
 <!--lint enable awesome-list-item-->
 
 ## OLAP Databases


### PR DESCRIPTION
## Why

The `awesome-lint` workflow has failed on every `main` run since 2026-07-01:

```
16:1  ToC missing item for "📝 License"  remark-lint:awesome-toc
```

`## 📝 License` exists as a heading but was never added to the Contents list, and awesome-lint requires every heading to be listed.

## What changed

One line added to the Contents list. No content or heading changes.

## Verified

`awesome-lint README.md` no longer reports the ToC error. The only remaining local error is `Awesome list must reside in a valid git repository`, which is an artifact of the local sandbox not resolving the SSH remote — CI checks out over HTTPS, so it does not apply there. CI on this PR is the real confirmation.
